### PR TITLE
Allow simple-cache v2 & v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": ">=7.3",
-        "cache/adapter-common": "^1.3",
+        "cache/adapter-common": "dev-SN-1682 as 1.3.2",
         "cache/hierarchical-cache": "^1.2",
         "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
@@ -55,5 +55,12 @@
         "branch-alias": {
             "dev-master": "1.1-dev"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:kaboodle-solutions/adapter-common.git",
+            "no-api": true
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": ">=7.3",
-        "cache/adapter-common": "^1.0",
-        "cache/hierarchical-cache": "^1.0",
+        "cache/adapter-common": "^1.3",
+        "cache/hierarchical-cache": "^1.2",
         "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": ">=7.3",
-        "cache/adapter-common": "dev-SN-1682 as 1.3.2",
+        "cache/adapter-common": "^1.3",
         "cache/hierarchical-cache": "^1.2",
         "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"


### PR DESCRIPTION
This pull request updates the version constraint for the `psr/simple-cache` dependency in `composer.json` to allow compatibility with newer versions.

Dependency compatibility update:

* Expanded the supported versions of `psr/simple-cache` to include `^2.0` and `^3.0` in addition to `^1.0` in the `composer.json` file, improving compatibility with projects using newer versions of this package.